### PR TITLE
Add explicit left, right and bottom margins to all charts. 

### DIFF
--- a/source/javascripts/site.js
+++ b/source/javascripts/site.js
@@ -2,10 +2,7 @@
   // Resize all graphs that need it
   var resizeGraphs = function() {
     $('.plotly-graph-needs-resize').each(function() {
-      let id = this.id;
-      requestAnimationFrame(function() {
-        Plotly.relayout(id, {});        
-      });
+      Plotly.relayout(this.id, {});
     });
   };
 

--- a/source/javascripts/site.js
+++ b/source/javascripts/site.js
@@ -2,7 +2,10 @@
   // Resize all graphs that need it
   var resizeGraphs = function() {
     $('.plotly-graph-needs-resize').each(function() {
-      Plotly.relayout(this.id, {});
+      let id = this.id;
+      requestAnimationFrame(function() {
+        Plotly.relayout(id, {});        
+      });
     });
   };
 

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -35,7 +35,7 @@ datasets += (current_page.data.datasets || [])
   <script>
     var default_layout = {
       autosize: true,
-      margin: { t: 0 },
+      margin: { t: 0, l:30, r:15, b:45 },
       legend: {"orientation": "h", "traceorder": "normal"}
     };
     var default_config = {


### PR DESCRIPTION
Aligning them correctly on desktop, and making them readable on mobile.

Mobile Before
![Before](https://user-images.githubusercontent.com/62819184/77837274-05e1f300-71b3-11ea-9e9c-4f8410119416.png)

Mobile After
![After](https://user-images.githubusercontent.com/62819184/77837272-02e70280-71b3-11ea-9c30-3fd65d990355.png)

Desktop Before
![Before](https://user-images.githubusercontent.com/62819184/77837276-067a8980-71b3-11ea-92e0-ac4e4cf24f7f.png)

Desktop After
![After](https://user-images.githubusercontent.com/62819184/77837278-07132000-71b3-11ea-9083-3f3bce845e9f.png)