### PR TITLE
Asynchronously re-layout each of the graphs when resizing.

### DIFF
--- a/source/javascripts/site.js
+++ b/source/javascripts/site.js
@@ -2,7 +2,10 @@
   // Resize all graphs that need it
   var resizeGraphs = function() {
     $('.plotly-graph-needs-resize').each(function() {
-      Plotly.relayout(this.id, {});
+      let id = this.id;
+      requestAnimationFrame(function() {
+        Plotly.relayout(id, {});        
+      });
     });
   };
 


### PR DESCRIPTION
Doing increases the pages responsiveness during resize events, and when toggling the sidebar on mobile.

Notably, toggling the sidebar now takes 20ms to respond to the users click (with the charts updating after ~220ms), whereas prior to this change toggling the sidebar took ~210ms to respond to the users click). --Times measured on a modern macbook simulating a mobile device