### PR TITLE
Remove icons from page top bar.

### DIFF
--- a/source/_top_totals.html.erb
+++ b/source/_top_totals.html.erb
@@ -6,9 +6,6 @@
           <div class="text-xs font-weight-bold text-primary text-uppercase mb-1">Confirmed Cases</div>
           <div class="h5 mb-0 font-weight-bold text-gray-800"><script>document.write(latest_numbers['confirmed'] != null ? latest_numbers['confirmed'].toLocaleString() : "unknown");</script></div>
         </div>
-        <div class="col-auto">
-          <i class="fas fa-meh fa-2x text-gray-300"></i>
-        </div>
       </div>
     </div>
   </div>
@@ -22,9 +19,6 @@
           <div class="text-xs font-weight-bold text-primary text-uppercase mb-1">Deaths</div>
           <div class="h5 mb-0 font-weight-bold text-gray-800"><script>document.write(latest_numbers['deaths'] != null ? latest_numbers['deaths'].toLocaleString() : "unknown");</script></div>
         </div>
-        <div class="col-auto">
-          <i class="fas fa-sad-tear fa-2x text-gray-300"></i>
-        </div>
       </div>
     </div>
   </div>
@@ -37,9 +31,6 @@
         <div class="col mr-2">
           <div class="text-xs font-weight-bold text-primary text-uppercase mb-1">Recovered</div>
           <div class="h5 mb-0 font-weight-bold text-gray-800"><script>document.write(latest_numbers['recovered'] != null ? latest_numbers['recovered'].toLocaleString() : "unknown");</script></div>
-        </div>
-        <div class="col-auto">
-          <i class="fas fa-smile fa-2x text-gray-300"></i>
         </div>
       </div>
     </div>
@@ -58,9 +49,6 @@
           document.write(percent.toLocaleString());
           </script>%
           </div>
-        </div>
-        <div class="col-auto">
-          <i class="fas fa-percent fa-2x text-gray-300"></i>
         </div>
       </div>
     </div>


### PR DESCRIPTION
The icons on the top bar don't really add much and these ones lean a bit too far towards being superficial when the numbers next to them are quite meaningful, so let's remove the icons.

Fixes https://github.com/theojulienne/covid-19-graphics/issues/7